### PR TITLE
Mastodon 2.6.0: Conversation API and min_id support

### DIFF
--- a/src/client/EventHandler.ts
+++ b/src/client/EventHandler.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'eventemitter3';
 import * as querystring from 'querystring';
+import { Conversation } from 'src/entities/Conversation';
 import * as WebSocket from 'websocket';
 import { Notification } from '../entities/Notification';
 import { Status } from '../entities/Status';
@@ -16,6 +17,9 @@ interface EventTypes {
 
   /** User's filter changed */
   filters_changed: undefined;
+
+  /** Status added to a conversation */
+  conversation: Conversation;
 
   /** WebSocket connected */
   connect: WebSocket.connection;

--- a/src/client/Mastodon.ts
+++ b/src/client/Mastodon.ts
@@ -927,6 +927,8 @@ export class Mastodon extends Gateway {
    * @see https://github.com/tootsuite/documentation/blob/master/Using-the-API/API.md#retrieving-a-timeline
    */
   public fetchDirectTimeline (options?: Options.FetchTimeline) {
+    // tslint:disable-next-line no-console
+    console.warn('Direct timeline API has been deprecated. See https://github.com/tootsuite/mastodon/releases/tag/v2.6.0rc1');
     return this.paginationGenerator<Status[]>(`${this.url}/api/v1/timelines/direct`, options);
   }
 

--- a/src/client/Mastodon.ts
+++ b/src/client/Mastodon.ts
@@ -3,6 +3,7 @@ import { EventHandler } from './EventHandler';
 import { getNextUrl } from './linkHeader';
 import * as Options from './options';
 
+import { Conversation } from 'src/entities/Conversation';
 import { Account } from '../entities/Account';
 import { Attachment } from '../entities/Attachment';
 import { Card } from '../entities/Card';
@@ -927,6 +928,13 @@ export class Mastodon extends Gateway {
    */
   public fetchDirectTimeline (options?: Options.FetchTimeline) {
     return this.paginationGenerator<Status[]>(`${this.url}/api/v1/timelines/direct`, options);
+  }
+
+  /**
+   * Retrieving a conversation timeline
+   */
+  public fetchConversations () {
+    return this.get<Conversation>(`${this.url}/api/v1/conversations`);
   }
 
   /**

--- a/src/client/Mastodon.ts
+++ b/src/client/Mastodon.ts
@@ -98,6 +98,15 @@ export class Mastodon extends Gateway {
   }
 
   /**
+   * Starting direct timeline streaming
+   * @return Instance of EventEmitter
+   * @see https://github.com/tootsuite/documentation/blob/master/Using-the-API/Streaming-API.md
+   */
+  public streamDirectTimeline (): EventHandler {
+    return this.stream(`${this.streamingUrl}/api/v1/streaming`, { stream: 'direct' });
+  }
+
+  /**
    * Fetch access token from authorization code
    * @param code code
    * @param client_id client_id of your app

--- a/src/client/options.ts
+++ b/src/client/options.ts
@@ -7,8 +7,11 @@ export interface Pagination {
   /** Get a list of items with ID less than this value */
   max_id?: string;
 
-  /** Get a list of items with ID greater than this value */
+  /** Get a list of items with ID greater than this value including this ID */
   since_id?: string;
+
+  /** Get a list of items with ID greater than this value exluding this ID */
+  min_id?: number;
 
   /** Maximum number of items to get */
   limit?: number;

--- a/src/entities/Conversation.ts
+++ b/src/entities/Conversation.ts
@@ -1,0 +1,16 @@
+import { Account } from './Account';
+import { Status } from './Status';
+
+export interface Conversation {
+  /** The ID of the conversation */
+  id: string;
+
+  /** Wether authorized user has read latest status */
+  unread: boolean;
+
+  /** An array of accounts that mentioned this conversation */
+  accounts: Account[];
+
+  /** The latest status of this conversation */
+  last_status: Status;
+}


### PR DESCRIPTION
This PR is including the supports of upcoming the new version of Mastodon. Conversation API and `min_id` support of pagination.

### References
- tootsuite/mastodon#8832
- tootsuite/mastodon#8736