### PR TITLE
Sets search API version properly; uses GET instead. Fixes #26.

### DIFF
--- a/src/client/Mastodon.ts
+++ b/src/client/Mastodon.ts
@@ -769,7 +769,7 @@ export class Mastodon extends Gateway {
    * @return Returns Results
    * @see https://docs.joinmastodon.org/api/rest/search/#get-api-v2-search
    */
-  public async search <V extends 'v1'|'v2' = 'v2'> (q: string, resolve = false, version = 'v2') {
+  public async search <V extends 'v1'|'v2' = 'v2'> (q: string, resolve = false, version = 'v2' as V) {
     return (await this.get<Results<V>>(`${this.url}/api/${version}/search`, { q, resolve })).data;
   }
 

--- a/src/client/Mastodon.ts
+++ b/src/client/Mastodon.ts
@@ -769,8 +769,8 @@ export class Mastodon extends Gateway {
    * @return Returns Results
    * @see https://docs.joinmastodon.org/api/rest/search/#get-api-v2-search
    */
-  public async search <V extends 'v1'|'v2' = 'v2'> (q: string, resolve = false, version?: V) {
-    return (await this.post<Results<V>>(`${this.url}/api/${version}/search`, { q, resolve })).data;
+  public async search <V extends 'v1'|'v2' = 'v2'> (q: string, resolve = false, version = 'v2') {
+    return (await this.get<Results<V>>(`${this.url}/api/${version}/search`, { q, resolve })).data;
   }
 
   /**


### PR DESCRIPTION
Worth noting you *should* be able to set the version type to a literal constraint as you've done, but it seems there's a bug in current TypeScript preventing it. 